### PR TITLE
Add a checkbox to save the consolidated project as zip

### DIFF
--- a/consolidatethread.py
+++ b/consolidatethread.py
@@ -120,7 +120,7 @@ class ConsolidateThread(QThread):
 
         if self.saveToZip:
             self.rangeChanged.emit(len(outFiles))
-            # strip .qgis from the project name
+            # strip .qgs from the project name
             self.zipfiles(outFiles, self.projectFile[:-4])
 
         if not interrupted:

--- a/consolidatethread.py
+++ b/consolidatethread.py
@@ -170,6 +170,7 @@ class ConsolidateThread(QThread):
         :param file_paths: list of path names
         :param archive: path of the archive
         """
+        archive = "%s.zip" % archive
         prefix = len(
             os.path.commonprefix([os.path.dirname(f) for f in file_paths]))
         with zipfile.ZipFile(

--- a/consolidatethread.py
+++ b/consolidatethread.py
@@ -119,6 +119,7 @@ class ConsolidateThread(QThread):
         self.saveProject(doc)
 
         if self.saveToZip:
+            self.rangeChanged.emit(len(outFiles))
             self.zipfiles(outFiles, self.projectFile[:-4])
 
         if not interrupted:
@@ -177,6 +178,7 @@ class ConsolidateThread(QThread):
                 archive, 'w', zipfile.ZIP_DEFLATED, allowZip64=True) as z:
             for f in file_paths:
                 z.write(f, f[prefix:])
+                self.updateProgress.emit()
 
     def copyXmlRasterLayer(self, layerElement, vLayer, layerName):
         outFile = "%s/%s.xml" % (self.layersDir, layerName)

--- a/consolidatethread.py
+++ b/consolidatethread.py
@@ -120,6 +120,7 @@ class ConsolidateThread(QThread):
 
         if self.saveToZip:
             self.rangeChanged.emit(len(outFiles))
+            # strip .qgis from the project name
             self.zipfiles(outFiles, self.projectFile[:-4])
 
         if not interrupted:

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -52,10 +52,10 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
         self.btnOk.setEnabled(False)
         self.btnClose = self.buttonBox.button(QDialogButtonBox.Close)
 
-        # FIXME: delete
-        # self.project_name_lbl = QLabel('project name')
+        # FIXME: this is needed if you can't compile the UI
+        # self.project_name_lbl = QLabel('Project name')
         # self.project_name_le = QLineEdit()
-        # self.checkBoxZip = QCheckBox('Zìppalo!')
+        # self.checkBoxZip = QCheckBox('Consolidate in a Zip file')
         # self.layout().addWidget(self.project_name_lbl)
         # self.layout().addWidget(self.project_name_le)
         # self.layout().addWidget(self.checkBoxZip)

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -178,6 +178,10 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
 
     def processFinished(self):
         self.stopProcessing()
+        QMessageBox.information(self,
+                                self.tr("OQ-Consolidate: Info"),
+                                'Consolidation complete.'
+                                )
         self.restoreGui()
 
     def processInterrupted(self):

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -52,6 +52,14 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
         self.btnOk.setEnabled(False)
         self.btnClose = self.buttonBox.button(QDialogButtonBox.Close)
 
+        # FIXME: delete
+        # self.project_name_lbl = QLabel('project name')
+        # self.project_name_le = QLineEdit()
+        # self.checkBoxZip = QCheckBox('Zìppalo!')
+        # self.layout().addWidget(self.project_name_lbl)
+        # self.layout().addWidget(self.project_name_le)
+        # self.layout().addWidget(self.checkBoxZip)
+
         self.project_name_le.textChanged.connect(
             self.on_project_name_changed)
         self.leOutputDir.textChanged.connect(
@@ -142,7 +150,9 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
             p.write(f)
 
         # start consolidate thread that does all real work
-        self.workThread = consolidatethread.ConsolidateThread(self.iface, outputDir, newProjectFile)
+        self.workThread = consolidatethread.ConsolidateThread(
+            self.iface, outputDir, newProjectFile,
+            self.checkBoxZip.isChecked())
         self.workThread.rangeChanged.connect(self.setProgressRange)
         self.workThread.updateProgress.connect(self.updateProgress)
         self.workThread.processFinished.connect(self.processFinished)

--- a/ui/qconsolidatedialogbase.ui
+++ b/ui/qconsolidatedialogbase.ui
@@ -7,27 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>144</height>
+    <height>189</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>OQ-Consolidate</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <widget class="QProgressBar" name="progressBar">
      <property name="value">
       <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -61,6 +51,23 @@
    </item>
    <item row="0" column="2">
     <widget class="QLineEdit" name="project_name_le"/>
+   </item>
+   <item row="4" column="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QCheckBox" name="checkBoxZip">
+     <property name="text">
+      <string>Consolidate in a Zip file</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
@ptormene I'm opening the PR just because I've updated the UI (using QtDesigner). Logic is still missing:

![qconsolidatedialogbase](https://user-images.githubusercontent.com/1818657/33388961-bbbb442c-d531-11e7-9f21-e64fdfb8ecbd.png)

I would, for now, use the following semantic:
- Keep input fields as they are (name + dest folder)
- if zip checkbox unselected: save qgs + layers in the folder selected
- if zip checkbox selected: save a zip file with qgs + layers in the folder selected