### PR TITLE
Save the project in a nested directory with respect to the one chosen by the user

### DIFF
--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -128,7 +128,11 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
         # create main directory if not exists
         d = QDir(outputDir)
         if not d.exists():
-            d.mkpath(".")
+            if not d.mkpath("."):
+                QMessageBox.critical(
+                    self, self.tr("OQ-Consolidate: Error"),
+                    self.tr("Can't create directory to store the project."))
+                return
 
         # create directory for layers if not exists
         if d.exists("layers"):

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -122,7 +122,8 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
                 self, self.tr("OQ-Consolidate: Error"),
                 self.tr("Please specify the output directory."))
             return
-        outputDir = os.path.join(outputDir, project_name)
+        outputDir = os.path.join(outputDir,
+                                 get_valid_filename(project_name))
 
         # create main directory if not exists
         d = QDir(outputDir)

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -122,9 +122,14 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
                 self, self.tr("OQ-Consolidate: Error"),
                 self.tr("Please specify the output directory."))
             return
+        outputDir = os.path.join(outputDir, project_name)
+
+        # create main directory if not exists
+        d = QDir(outputDir)
+        if not d.exists():
+            d.mkpath(".")
 
         # create directory for layers if not exists
-        d = QDir(outputDir)
         if d.exists("layers"):
             res = QMessageBox.question(
                 self, self.tr("Directory exists"),


### PR DESCRIPTION
Instead of saving the project in the directory that is chosen by the user, this PR creates a nested directory with the (laundered) name of the current project, and saves everything inside the nested directory.
This makes things slightly quicker for users, because they don't need to explicitly create the nested directory.