### PR TITLE
Cleanup project name on editingFinished instead of on textChanged

### DIFF
--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -70,8 +70,8 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
         # self.layout().addWidget(self.project_name_le)
         # self.layout().addWidget(self.checkBoxZip)
 
-        self.project_name_le.textChanged.connect(
-            self.on_project_name_changed)
+        self.project_name_le.editingFinished.connect(
+            self.on_project_name_editing_finished)
         self.leOutputDir.textChanged.connect(
             self.set_ok_button)
 
@@ -81,7 +81,7 @@ class QConsolidateDialog(QDialog, Ui_QConsolidateDialog):
 
         self.btnBrowse.clicked.connect(self.setOutDirectory)
 
-    def on_project_name_changed(self):
+    def on_project_name_editing_finished(self):
         try:
             valid_filename = get_valid_filename(self.project_name_le.text())
         except UnicodeEncodeError:


### PR DESCRIPTION
If the project name is laundered while the user is still editing it, the cursor is moved to the end of the name and it becomes impossible to add more than one character at a time.
Instead of using the signal `textChanged`, we can use `editingFinished`, that is triggered when the user has completed the editing.